### PR TITLE
disable generate link button when missing data

### DIFF
--- a/react-app/src/GenerateLink.js
+++ b/react-app/src/GenerateLink.js
@@ -202,6 +202,9 @@ export const GenerateLink = () => {
           />
           <button
             className="submit-button"
+            disabled={
+              myAddress === "" || peerAddress === "" || sendAmount == "" || receiveAmount === "" ? true : false
+            }
             onClick={async () => {
               const { generate_unsigned_swap_transactions, generate_link } =
                 await wasmPromise;

--- a/react-app/src/GenerateLink.js
+++ b/react-app/src/GenerateLink.js
@@ -203,7 +203,7 @@ export const GenerateLink = () => {
           <button
             className="submit-button"
             disabled={
-              myAddress === "" || peerAddress === "" || sendAmount == "" || receiveAmount === "" ? true : false
+              myAddress === "" || peerAddress === "" || sendAmount === "" || receiveAmount === "" ? true : false
             }
             onClick={async () => {
               const { generate_unsigned_swap_transactions, generate_link } =


### PR DESCRIPTION
This change disables the generate link button when information necessary
to the transaction has not been set. In particular:
- myAddress
- peerAddress
- sendAmount
- receiveAmount

must have some value set in order for the generate link button to become
enabled.