### PR TITLE
provide user a disconnect button after connecting

### DIFF
--- a/react-app/src/GenerateLink.js
+++ b/react-app/src/GenerateLink.js
@@ -108,6 +108,32 @@ export const GenerateLink = () => {
     }
   };
 
+const connectButtonElement = () => {
+    if (myAddress === "") {
+      return (
+        <button
+          className="connect-button"
+          onClick={async (event) => {
+            let addresses = await connectWallet();
+            setMyAddress(addresses[0]);
+          }}
+          >
+          {"Connect My Algo wallet"}
+        </button>
+      );
+    } else {
+      return <button
+              className="connect-button"
+              onClick={() => {
+                setMyAddress("");
+              }}
+              >
+              {"Disconnect"}
+            </button>
+    }
+  };
+
+
   return (
     <div>
       <div className="form">
@@ -117,15 +143,7 @@ export const GenerateLink = () => {
           }
         </div>
         <div>{"Generate a link to swap Algos, ASAs or NFTs with a peer"}</div>
-        <button
-          className="connect-button"
-          onClick={async (event) => {
-            let addresses = await connectWallet();
-            setMyAddress(addresses[0]);
-          }}
-        >
-          {"Connect My Algo wallet"}
-        </button>
+        {connectButtonElement()}
         {yourAddressElement()}
         {errorMsgElement()}
         <div>


### PR DESCRIPTION
After a user has connected a myAlgo wallet the ui should remove the
original `connect` button and replace it with a `Disconnect` button.
This should help the user understand that the connect request was
successful and the application "knows" about the connected address.

The disconnect button allows the user to reset the application state by
setting `myAddress` back to an empty string.