### PR TITLE
allow user to provide a purestake api key

### DIFF
--- a/react-app/src/GenerateLink.js
+++ b/react-app/src/GenerateLink.js
@@ -28,6 +28,7 @@ export const GenerateLink = () => {
   const [errorMsg, setErrorMsg] = useState("");
 
   const [showLinkModal, setShowLinkModal] = useState(false);
+  const [apiKey, setApiKey] = useState("");
 
   useEffect(() => {
     const init = async () => {
@@ -169,6 +170,17 @@ export const GenerateLink = () => {
         {yourAddressElement()}
         {errorMsgElement()}
         <div>
+        <div>{"Purestake api key"}</div>
+          <input
+            type="password"
+            placeholder="api key"
+            className="address-input"
+            size="64"
+            value={apiKey}
+            onChange={(event) => {
+              setApiKey(event.target.value);
+            }}
+          />
           <div>{"Peer"}</div>
           <input
             placeholder="Peer address"
@@ -272,7 +284,7 @@ export const GenerateLink = () => {
 
                     my_fee: myFee,
                     peer_fee: peerFee,
-                  });
+                  }, apiKey);
 
                 let rawSwapRequest = {
                   signed_my_tx_msg_pack: await sign(
@@ -282,7 +294,7 @@ export const GenerateLink = () => {
                     unsignedSwapTransactions.peer_tx_msg_pack, // passthrough
                 };
 
-                let link = await generate_link(rawSwapRequest);
+                let link = await generate_link(rawSwapRequest, apiKey);
                 setSwapLink(link);
                 setSwapLinkTruncated(
                   link.replace(/(.*)\/(.*).(?=....)/, "$1/...")

--- a/react-app/src/GenerateLink.js
+++ b/react-app/src/GenerateLink.js
@@ -28,6 +28,7 @@ export const GenerateLink = () => {
   const [errorMsg, setErrorMsg] = useState("");
 
   const [showLinkModal, setShowLinkModal] = useState(false);
+  const [showPurestakeHelpModal, setShowPurestakeHelpModal] = useState(false);
   const [apiKey, setApiKey] = useState("");
 
   useEffect(() => {
@@ -107,6 +108,22 @@ export const GenerateLink = () => {
     }
   };
 
+  const purestakeHelpElement = () => {
+    return (
+      <div>
+        <p>
+          <a target="_blank" href="https://www.purestake.com/">Purestake</a> provides a service
+          that allows swaplink to submit transactions to the algorand blockchain without requiring
+          a connection to an algorand node.
+        </p>
+        <p>
+          Algorand has provided a detailed, step-by-step tutorial on how to sign up for purestake and
+          how to obtain an API key here: <a target="_blank" href="https://developer.algorand.org/tutorials/getting-started-purestake-api-service/">Getting Started with the PureStake API Service</a>
+        </p>
+      </div>
+    );
+  };
+
   const onCopyText = () => {
     setSwapLinkIsCopied(true);
     setTimeout(() => {
@@ -170,7 +187,10 @@ export const GenerateLink = () => {
         {yourAddressElement()}
         {errorMsgElement()}
         <div>
-        <div>{"Purestake api key"}</div>
+          <div>
+            {"Purestake api key "}
+            <a href="#" onClick={() => setShowPurestakeHelpModal(true)}>?</a>
+          </div>
           <input
             type="password"
             placeholder="api key"
@@ -310,6 +330,11 @@ export const GenerateLink = () => {
           {showLinkModal && (
             <Modal title={"Done!"} onCloseClick={() => setShowLinkModal(false)}>
               {swapLinkElement()}
+            </Modal>
+          )}
+          {showPurestakeHelpModal && (
+            <Modal title={"Purestake API key help"} onCloseClick={() => setShowPurestakeHelpModal(false)}>
+              {purestakeHelpElement()}
             </Modal>
           )}
         </div>

--- a/react-app/src/SubmitLink.js
+++ b/react-app/src/SubmitLink.js
@@ -12,11 +12,12 @@ export const SubmitLink = () => {
   const [swapViewData, setSwapViewData] = useState(null);
   const [errorMsg, setErrorMsg] = useState("");
   const [successMsg, setSuccessMsg] = useState("");
+  const [apiKey, setApiKey] = useState("");
 
   useEffect(() => {
     const init = async () => {
       const { init_log, decode_link } = await wasmPromise;
-      const swapRequest = await decode_link(link);
+      const swapRequest = await decode_link(link, apiKey);
 
       init_log();
       setSwapRequest(swapRequest);
@@ -111,7 +112,7 @@ export const SubmitLink = () => {
                 ),
                 signed_peer_tx_msg_pack: swapRequest.signed_peer_tx_msg_pack, // passthrough
               };
-              const tx_id = await submit_transactions(signed_txns);
+              const tx_id = await submit_transactions(signed_txns, apiKey);
               setSuccessMsg("Swap submitted! Tx id: " + tx_id);
             } catch (e) {
               setErrorMsg(e + "");

--- a/wasm/src/dependencies.rs
+++ b/wasm/src/dependencies.rs
@@ -25,10 +25,7 @@ pub fn submit_swap_logic(algod: Rc<Algod>, indexer: Rc<Indexer>) -> SubmitSwapLo
 fn testnet_algod(api_key: &str) -> Algod {
     AlgodCustomEndpointBuilder::new()
         .bind("https://testnet-algorand.api.purestake.io/ps2/")
-        .headers(vec![(
-            "x-api-key",
-            api_key,
-        )])
+        .headers(vec![("x-api-key", api_key)])
         .build_v2()
         // expect: build returns an error if the URL or token are not provided or have an invalid format,
         // we are passing verified hardcoded values.
@@ -38,10 +35,7 @@ fn testnet_algod(api_key: &str) -> Algod {
 fn testnet_indexer(api_key: &str) -> Indexer {
     IndexerCustomEndpointBuilder::new()
         .bind("https://testnet-algorand.api.purestake.io/idx2/")
-        .headers(vec![(
-            "x-api-key",
-            api_key,
-        )])
+        .headers(vec![("x-api-key", api_key)])
         .build_v2()
         // expect: build returns an error if the URL or token are not provided or have an invalid format,
         // we are passing verified hardcoded values.

--- a/wasm/src/dependencies.rs
+++ b/wasm/src/dependencies.rs
@@ -6,12 +6,12 @@ use algonaut::{
     indexer::{v2::Indexer, IndexerBuilder, IndexerCustomEndpointBuilder},
 };
 
-pub fn algod() -> Algod {
-    testnet_algod()
+pub fn algod(api_key: &str) -> Algod {
+    testnet_algod(api_key)
 }
 
-pub fn indexer() -> Indexer {
-    testnet_indexer()
+pub fn indexer(api_key: &str) -> Indexer {
+    testnet_indexer(api_key)
 }
 
 pub fn generate_swap_logic(algod: Rc<Algod>, indexer: Rc<Indexer>) -> GenerateSwapLogic {
@@ -22,12 +22,12 @@ pub fn submit_swap_logic(algod: Rc<Algod>, indexer: Rc<Indexer>) -> SubmitSwapLo
     SubmitSwapLogic::new(algod, indexer)
 }
 
-fn testnet_algod() -> Algod {
+fn testnet_algod(api_key: &str) -> Algod {
     AlgodCustomEndpointBuilder::new()
         .bind("https://testnet-algorand.api.purestake.io/ps2/")
         .headers(vec![(
             "x-api-key",
-            "Ii8MvLymlZ8mxE5hT94KG4nEWfH1A7cP6WMWTfkk",
+            api_key,
         )])
         .build_v2()
         // expect: build returns an error if the URL or token are not provided or have an invalid format,
@@ -35,12 +35,12 @@ fn testnet_algod() -> Algod {
         .expect("Couldn't initialize algod")
 }
 
-fn testnet_indexer() -> Indexer {
+fn testnet_indexer(api_key: &str) -> Indexer {
     IndexerCustomEndpointBuilder::new()
         .bind("https://testnet-algorand.api.purestake.io/idx2/")
         .headers(vec![(
             "x-api-key",
-            "Ii8MvLymlZ8mxE5hT94KG4nEWfH1A7cP6WMWTfkk",
+            api_key,
         )])
         .build_v2()
         // expect: build returns an error if the URL or token are not provided or have an invalid format,

--- a/wasm/src/js_bridge.rs
+++ b/wasm/src/js_bridge.rs
@@ -27,7 +27,7 @@ pub async fn init_log() -> Result<(), String> {
 pub async fn generate_unsigned_swap_transactions(
     my_address_str: String,
     inputs: JsValue,
-    api_key: String
+    api_key: String,
 ) -> Result<JsValue, String> {
     let inputs = inputs.into_serde().map_err(to_js_value)?;
 
@@ -95,7 +95,10 @@ pub async fn decode_link(swap_link: String, api_key: String) -> Result<JsValue, 
 
 // Receiver submits the signed tx pair
 #[wasm_bindgen]
-pub async fn submit_transactions(raw_signed_txns: JsValue, api_key: String) -> Result<String, String> {
+pub async fn submit_transactions(
+    raw_signed_txns: JsValue,
+    api_key: String,
+) -> Result<String, String> {
     let raw_txns = raw_signed_txns
         .into_serde::<SignedTxnsFromJs>()
         .map_err(to_js_value)?;

--- a/wasm/src/js_bridge.rs
+++ b/wasm/src/js_bridge.rs
@@ -27,10 +27,11 @@ pub async fn init_log() -> Result<(), String> {
 pub async fn generate_unsigned_swap_transactions(
     my_address_str: String,
     inputs: JsValue,
+    api_key: String
 ) -> Result<JsValue, String> {
     let inputs = inputs.into_serde().map_err(to_js_value)?;
 
-    let txns = generate_swap_logic()
+    let txns = generate_swap_logic(&api_key)
         .generate_unsigned_swap_transactions(my_address_str, inputs)
         .await
         .map_err(to_js_value)?;
@@ -48,7 +49,7 @@ pub async fn generate_unsigned_swap_transactions(
 
 /// Signed "my tx" + passthrough peer tx -> link
 #[wasm_bindgen]
-pub async fn generate_link(raw_request_js: JsValue) -> Result<JsValue, String> {
+pub async fn generate_link(raw_request_js: JsValue, api_key: String) -> Result<JsValue, String> {
     let raw_request = raw_request_js
         .into_serde::<SwapRequestFromJs>()
         .map_err(to_js_value)?;
@@ -60,7 +61,7 @@ pub async fn generate_link(raw_request_js: JsValue) -> Result<JsValue, String> {
             .map_err(to_js_value)?,
     };
 
-    let link = generate_swap_logic()
+    let link = generate_swap_logic(&api_key)
         .generate_link(&request)
         .await
         .map_err(to_js_value)?;
@@ -70,8 +71,8 @@ pub async fn generate_link(raw_request_js: JsValue) -> Result<JsValue, String> {
 
 /// Receiver decodes link
 #[wasm_bindgen]
-pub async fn decode_link(swap_link: String) -> Result<JsValue, String> {
-    let logic = submit_swap_logic();
+pub async fn decode_link(swap_link: String, api_key: String) -> Result<JsValue, String> {
+    let logic = submit_swap_logic(&api_key);
 
     let request = logic
         .to_swap_request(swap_link)
@@ -94,7 +95,7 @@ pub async fn decode_link(swap_link: String) -> Result<JsValue, String> {
 
 // Receiver submits the signed tx pair
 #[wasm_bindgen]
-pub async fn submit_transactions(raw_signed_txns: JsValue) -> Result<String, String> {
+pub async fn submit_transactions(raw_signed_txns: JsValue, api_key: String) -> Result<String, String> {
     let raw_txns = raw_signed_txns
         .into_serde::<SignedTxnsFromJs>()
         .map_err(to_js_value)?;
@@ -102,23 +103,23 @@ pub async fn submit_transactions(raw_signed_txns: JsValue) -> Result<String, Str
     let my_tx = rmp_serde::from_slice(&raw_txns.signed_my_tx_msg_pack).map_err(to_js_value)?;
     let peer_tx = rmp_serde::from_slice(&raw_txns.signed_peer_tx_msg_pack).map_err(to_js_value)?;
 
-    submit_swap_logic()
+    submit_swap_logic(&api_key)
         .submit_swap(my_tx, peer_tx)
         .await
         .map_err(to_js_value)
 }
 
-fn generate_swap_logic() -> GenerateSwapLogic {
+fn generate_swap_logic(api_key: &str) -> GenerateSwapLogic {
     dependencies::generate_swap_logic(
-        Rc::new(dependencies::algod()),
-        Rc::new(dependencies::indexer()),
+        Rc::new(dependencies::algod(api_key)),
+        Rc::new(dependencies::indexer(api_key)),
     )
 }
 
-fn submit_swap_logic() -> SubmitSwapLogic {
+fn submit_swap_logic(api_key: &str) -> SubmitSwapLogic {
     dependencies::submit_swap_logic(
-        Rc::new(dependencies::algod()),
-        Rc::new(dependencies::indexer()),
+        Rc::new(dependencies::algod(api_key)),
+        Rc::new(dependencies::indexer(api_key)),
     )
 }
 


### PR DESCRIPTION
This change allows a user to provide a purestake api key which will be used when submitting network operations. 

This is a proof-of-concept approach where the api key is provided directly as an argument down the call stack. 

There may be a cleaner design that doesn't require the api key to be a part of so many signatures but I'd like to get feedback at this point before proceeding.